### PR TITLE
Standard compliance

### DIFF
--- a/src/mbd_geom.F90
+++ b/src/mbd_geom.F90
@@ -2,7 +2,7 @@
 ! License, v. 2.0. If a copy of the MPL was not distributed with this
 ! file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #ifndef LEGENDRE_PREC
-#define LEGENDRE_PREC 8
+#define LEGENDRE_PREC 15
 #endif
 #include "defaults.h"
 
@@ -272,7 +272,7 @@ subroutine gauss_legendre(n, r, w)
     integer, intent(in) :: n
     real(dp), intent(out) :: r(n), w(n)
 
-    integer, parameter :: q = LEGENDRE_PREC
+    integer, parameter :: q = selected_real_kind(LEGENDRE_PREC)
     integer, parameter :: n_iter = 1000
     real(q) :: x, f, df, dx
     integer :: k, iter, i

--- a/src/mbd_lapack.f90
+++ b/src/mbd_lapack.f90
@@ -354,7 +354,7 @@ subroutine eig_real(A, eigs, exc, src, vals_only)
         end if
         return
     endif
-    eigs = cmplx(eigs_r, eigs_i, 8)
+    eigs = cmplx(eigs_r, eigs_i, dp)
     if (mode(vals_only) == 'V') A = vectors
 end subroutine
 

--- a/src/mbd_linalg.F90
+++ b/src/mbd_linalg.F90
@@ -44,8 +44,8 @@ function eye(n) result(A)
 end function
 
 function get_diag_real(A) result(d)
-    real(8), intent(in) :: A(:, :)
-    real(8) :: d(size(A, 1))
+    real(dp), intent(in) :: A(:, :)
+    real(dp) :: d(size(A, 1))
 
     integer :: i
 

--- a/src/mbd_utils.F90
+++ b/src/mbd_utils.F90
@@ -17,6 +17,8 @@ private
 public :: tostr, diff3, diff5, print_matrix, lower, diff7, findval, shift_idx, &
     is_true, printer_i, printer
 
+integer, parameter :: i8 = selected_int_kind(18)
+
 interface tostr
     module procedure tostr_int
     module procedure tostr_real
@@ -76,7 +78,7 @@ end type
 type, public :: clock_t
     !! Used for measuring performance.
     logical :: active = .true.
-    integer(kind=8), allocatable :: timestamps(:), counts(:)
+    integer(i8), allocatable :: timestamps(:), counts(:)
     contains
     procedure :: init => clock_init
     procedure :: clock => clock_clock
@@ -219,15 +221,15 @@ subroutine clock_init(this, n)
     class(clock_t), intent(inout) :: this
     integer, intent(in) :: n
 
-    allocate (this%timestamps(n), source=0_8)
-    allocate (this%counts(n), source=0_8)
+    allocate (this%timestamps(n), source=0_i8)
+    allocate (this%counts(n), source=0_i8)
 end subroutine
 
 subroutine clock_clock(this, id)
     class(clock_t), intent(inout) :: this
     integer, intent(in) :: id
 
-    integer(kind=8) :: cnt, rate, cnt_max
+    integer(i8) :: cnt, rate, cnt_max
     integer :: absid
 
     if (.not. this%active) return
@@ -244,7 +246,7 @@ end subroutine
 subroutine clock_print(this)
     class(clock_t), intent(inout) :: this
 
-    integer(kind=8) :: cnt, rate, cnt_max
+    integer(i8) :: cnt, rate, cnt_max
     integer :: i
     character(len=20) :: label
 


### PR DESCRIPTION
We are running into some trouble compiling `libmbd` across the DFTB+ toolchains, here is what we got regarding Fortran standard violations so far:
- avoid using compiler specific kind parameter values, use `selected_real_kind` and `selected_int_kind` instead