### PR TITLE
Nagcomp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,10 @@ add_library(mbd
 
 if(ENABLE_SCALAPACK_MPI)
     target_sources(mbd PRIVATE mbd_mpi.F90 mbd_blacs.f90 mbd_scalapack.f90)
+    # NAG compiler won't compile this file without the '-mismatch' option
+    if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NAG")
+        set_source_files_properties(SOURCE mbd_mpi.F90 PROPERTY COMPILE_FLAGS -mismatch)
+    endif()
 endif()
 
 if(ENABLE_ELSI)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,10 +23,6 @@ add_library(mbd
 
 if(ENABLE_SCALAPACK_MPI)
     target_sources(mbd PRIVATE mbd_mpi.F90 mbd_blacs.f90 mbd_scalapack.f90)
-    # NAG compiler won't compile this file without the '-mismatch' option
-    if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NAG")
-        set_source_files_properties(SOURCE mbd_mpi.F90 PROPERTY COMPILE_FLAGS -mismatch)
-    endif()
 endif()
 
 if(ENABLE_ELSI)

--- a/src/mbd_blacs.f90
+++ b/src/mbd_blacs.f90
@@ -49,42 +49,50 @@ end interface
 interface
 
     subroutine blacs_pinfo(id, nproc)
+        implicit none
         integer, intent(out) :: id, nproc
     end subroutine blacs_pinfo
 
     subroutine blacs_gridinit(ictxt, order, nprow, npcol)
+        implicit none
         integer, intent(inout) :: ictxt
         character, intent(in) :: order
         integer, intent(in) :: nprow, npcol
     end subroutine blacs_gridinit
 
     subroutine blacs_gridinfo(ictxt, nprow, npcol, myrow, mycol)
+        implicit none
         integer, intent(in) :: ictxt,nprow, npcol
         integer, intent(out) :: myrow, mycol
     end subroutine blacs_gridinfo
 
     subroutine blacs_gridexit(ictxt)
+        implicit none
         integer, intent(in) :: ictxt
     end subroutine blacs_gridexit
 
     integer function numroc(nn, nb, iproc, isrcproc, nprocs)
+        implicit none
         integer, intent(in) :: nn, nb, iproc, isrcproc, nprocs
     end function numroc
 
     subroutine descinit(desc, mm, nn, mb, nb, irsrc, icsrc, ictxt, lld, info)
         import :: DLEN
+        implicit none
         integer, intent(out) :: desc(DLEN)
         integer, intent(in) :: mm, nn, mb, nb, irsrc, icsrc, ictxt, lld
         integer, intent(out) :: info
     end subroutine descinit
 
     subroutine blacs_get(ictxt, what, val)
+        implicit none
         integer, intent(in) :: ictxt, what
         integer, intent(out) :: val
     end subroutine blacs_get
 
     subroutine dgsum2d(ictxt, scope, top, mm, nn, aa, lda, rdest, cdest)
         import :: dp
+        implicit none
         integer, intent(in) :: ictxt
         character, intent(in) :: scope, top
         integer, intent(in) :: mm, nn
@@ -95,6 +103,7 @@ interface
 
     subroutine zgsum2d(ictxt, scope, top, mm, nn, aa, lda, rdest, cdest)
         import :: dp
+        implicit none
         integer, intent(in) :: ictxt
         character, intent(in) :: scope, top
         integer, intent(in) :: mm, nn

--- a/src/mbd_mpi.F90
+++ b/src/mbd_mpi.F90
@@ -28,38 +28,34 @@ subroutine mpi_all_reduce_real_0d(x, comm)
     real(dp), intent(inout) :: x
     integer, intent(in) :: comm
 
-    real(dp) :: x_buffer
+    real(dp) :: x_arr(1), x_buffer(1)
     integer :: ierr
 
-    call MPI_ALLREDUCE(x, x_buffer, 1, MPI_DOUBLE_PRECISION, MPI_SUM, comm, ierr)
-    x = x_buffer
-end subroutine
-
-subroutine mpi_all_reduce_real(x, n, comm)
-    integer, intent(in) :: n
-    real(dp), intent(inout) :: x(n)
-    integer, intent(in) :: comm
-
-    real(dp), allocatable :: x_buffer(:)
-    integer :: ierr
-
-    allocate (x_buffer(n))
-    call MPI_ALLREDUCE(x, x_buffer, n, MPI_DOUBLE_PRECISION, MPI_SUM, comm, ierr)
-    x = x_buffer
+    x_arr(1) = x
+    call MPI_ALLREDUCE(x_arr, x_buffer, 1, MPI_DOUBLE_PRECISION, MPI_SUM, comm, ierr)
+    x = x_buffer(1)
 end subroutine
 
 subroutine mpi_all_reduce_real_1d(x, comm)
     real(dp), intent(inout) :: x(:)
     integer, intent(in) :: comm
 
-    call mpi_all_reduce_real(x, size(x), comm)
+    real(dp), allocatable :: x_buffer(:)
+    integer :: ierr
+
+    allocate (x_buffer(size(x)))
+    call MPI_ALLREDUCE(x, x_buffer, size(x), MPI_DOUBLE_PRECISION, MPI_SUM, comm, ierr)
+    x = x_buffer
 end subroutine
 
 subroutine mpi_all_reduce_real_2d(x, comm)
-    real(dp), intent(inout) :: x(:, :)
+    real(dp), contiguous, target, intent(inout) :: x(:, :)
     integer, intent(in) :: comm
 
-    call mpi_all_reduce_real(x, size(x), comm)
+    real(dp), pointer :: x_p(:)
+
+    x_p(1:size(x)) => x
+    call mpi_all_reduce_real_1d(x_p, comm)
 end subroutine
 
 integer function mpi_get_rank() result(rank)

--- a/src/mbd_scalapack.f90
+++ b/src/mbd_scalapack.f90
@@ -32,110 +32,7 @@ interface peigvalsh
     module procedure peigvalsh_complex
 end interface
 
-
-integer, parameter :: DLEN = 9
-integer, parameter :: LLD = 9
-
-interface
-
-  subroutine pdsyev(jobz, uplo, nn, aa, ia, ja, desca, ww, zz, iz, jz, descz, work, lwork, info)
-    import :: dp, DLEN, LLD
-    implicit none
-    character, intent(in) :: jobz, uplo
-    integer, intent(in) :: nn
-    integer, intent(in) :: ia, ja, desca(DLEN)
-    real(dp), intent(inout) :: aa(desca(LLD), *)
-    integer, intent(in) :: iz, jz, descz(DLEN)
-    real(dp), intent(out) :: ww(nn), zz(descz(LLD),*)
-    real(dp), intent(inout) :: work(*)
-    integer, intent(in) :: lwork
-    integer, intent(out) :: info
-  end subroutine pdsyev
-
-  subroutine pdheev(jobz, uplo, nn, aa, ia, ja, desca, ww, zz, iz, jz, descz, work, lwork, rwork,&
-      & lrwork, info)
-    import :: dp, DLEN, LLD
-    implicit none
-    character, intent(in) :: jobz, uplo
-    integer, intent(in) :: nn
-    integer, intent(in) :: ia, ja, desca(DLEN)
-    complex(dp), intent(inout) :: aa(desca(LLD), *)
-    integer, intent(in) :: iz, jz, descz(DLEN)
-    real(dp), intent(out) :: ww(nn)
-    complex(dp), intent(out) ::  zz(descz(LLD),*)
-    complex(dp), intent(inout) :: work(*)
-    integer, intent(in) :: lwork
-    real(dp), intent(inout) :: rwork(*)
-    integer, intent(in) :: lrwork
-    integer, intent(out) :: info
-  end subroutine pdheev
-
-  subroutine pdgetrf(mm, nn, aa, ia, ja, desca, ipiv, info)
-    import :: dp, DLEN, LLD
-    implicit none
-    integer, intent(in) :: mm
-    integer, intent(in) :: nn
-    integer, intent(in) :: ia, ja, desca(DLEN)
-    real(dp), intent(inout) :: aa(desca(LLD), *)
-    integer, intent(out) :: ipiv(*)
-    integer, intent(out) :: info
-  end subroutine pdgetrf
-
-  subroutine pdgetri(nn, aa, ia, ja, desca, ipiv, work, lwork, iwork, liwork, info)
-    import :: dp, DLEN, LLD
-    implicit none
-    integer, intent(in) :: nn
-    integer, intent(in) :: desca(DLEN)
-    real(dp), intent(inout) :: aa(desca(LLD), *)
-    integer, intent(in) :: ia
-    integer, intent(in) :: ja
-    integer, intent(in) :: ipiv(*)
-    real(dp), intent(inout) :: work(*)
-    integer, intent(in) :: lwork
-    integer, intent(inout) :: iwork(*)
-    integer, intent(in) :: liwork
-    integer, intent(out) :: info
-  end subroutine pdgetri
-
-  subroutine pdgemm(transa, transb, mm, nn, kk, alpha, aa, ia, ja, desca, bb, ib, jb, descb, beta,&
-      & cc, ic, jc, descc)
-    import :: dp, DLEN, LLD
-    implicit none
-    character, intent(in) :: transa, transb
-    integer, intent(in) :: mm, nn, kk
-    real(dp), intent(in) :: alpha
-    integer, intent(in) :: desca(DLEN)
-    real(dp), intent(in) :: aa(desca(LLD), *)
-    integer, intent(in) :: ia, ja
-    integer, intent(in) :: descb(DLEN)
-    real(dp), intent(in) :: bb(descb(LLD), *)
-    integer, intent(in) :: ib, jb
-    real(dp), intent(in) :: beta
-    integer, intent(in) :: descc(DLEN)
-    real(dp), intent(inout) :: cc(descc(LLD), *)
-    integer, intent(in) :: ic, jc
-  end subroutine pdgemm
-
-  subroutine pzgemm(transa, transb, mm, nn, kk, alpha, aa, ia, ja, desca, bb, ib, jb, descb, beta,&
-      & cc, ic, jc, descc)
-    import :: dp, DLEN, LLD
-    implicit none
-    character, intent(in) :: transa, transb
-    integer, intent(in) :: mm, nn, kk
-    complex(dp), intent(in) :: alpha
-    integer, intent(in) :: desca(DLEN)
-    complex(dp), intent(in) :: aa(desca(LLD), *)
-    integer, intent(in) :: ia, ja
-    integer, intent(in) :: descb(DLEN)
-    complex(dp), intent(in) :: bb(descb(LLD), *)
-    integer, intent(in) :: ib, jb
-    complex(dp), intent(in) :: beta
-    integer, intent(in) :: descc(DLEN)
-    complex(dp), intent(inout) :: cc(descc(LLD), *)
-    integer, intent(in) :: ic, jc
-  end subroutine pzgemm
-
-end interface
+external :: PDSYEV, PZHEEV, PDGETRF, PDGETRI, PDGEMM, PZGEMM
 
 contains
 
@@ -147,8 +44,7 @@ subroutine pinvh_real(A, blacs, exc, src)
 
     integer, allocatable :: i_pivot(:), iwork_arr(:)
     real(dp), allocatable :: work_arr(:)
-    integer :: n, n_work_arr, error_flag, n_iwork_arr
-    integer :: n_iwork_arr_optim(1)
+    integer :: n, n_work_arr, error_flag, n_iwork_arr(1)
     real(dp) :: n_work_arr_optim(1)
 
     n = 3*blacs%n_atoms
@@ -166,14 +62,13 @@ subroutine pinvh_real(A, blacs, exc, src)
     endif
     call PDGETRI( &
         n, A, 1, 1, blacs%desc, i_pivot, &
-        n_work_arr_optim, -1, n_iwork_arr_optim, -1, error_flag &
+        n_work_arr_optim, -1, n_iwork_arr, -1, error_flag &
     )
     n_work_arr = nint(n_work_arr_optim(1))
-    n_iwork_arr = n_iwork_arr_optim(1)
-    allocate (work_arr(n_work_arr), iwork_arr(n_iwork_arr))
+    allocate (work_arr(n_work_arr), iwork_arr(n_iwork_arr(1)))
     call PDGETRI( &
         n, A, 1, 1, blacs%desc, i_pivot, &
-        work_arr, n_work_arr, iwork_arr, n_iwork_arr, error_flag)
+        work_arr, n_work_arr, iwork_arr, n_iwork_arr(1), error_flag)
     if (error_flag /= 0) then
         if (present(exc)) then
             exc%code = MBD_EXC_LINALG

--- a/src/mbd_scalapack.f90
+++ b/src/mbd_scalapack.f90
@@ -40,6 +40,7 @@ interface
 
   subroutine pdsyev(jobz, uplo, nn, aa, ia, ja, desca, ww, zz, iz, jz, descz, work, lwork, info)
     import :: dp, DLEN, LLD
+    implicit none
     character, intent(in) :: jobz, uplo
     integer, intent(in) :: nn
     integer, intent(in) :: ia, ja, desca(DLEN)
@@ -54,6 +55,7 @@ interface
   subroutine pdheev(jobz, uplo, nn, aa, ia, ja, desca, ww, zz, iz, jz, descz, work, lwork, rwork,&
       & lrwork, info)
     import :: dp, DLEN, LLD
+    implicit none
     character, intent(in) :: jobz, uplo
     integer, intent(in) :: nn
     integer, intent(in) :: ia, ja, desca(DLEN)
@@ -70,6 +72,7 @@ interface
 
   subroutine pdgetrf(mm, nn, aa, ia, ja, desca, ipiv, info)
     import :: dp, DLEN, LLD
+    implicit none
     integer, intent(in) :: mm
     integer, intent(in) :: nn
     integer, intent(in) :: ia, ja, desca(DLEN)
@@ -80,6 +83,7 @@ interface
 
   subroutine pdgetri(nn, aa, ia, ja, desca, ipiv, work, lwork, iwork, liwork, info)
     import :: dp, DLEN, LLD
+    implicit none
     integer, intent(in) :: nn
     integer, intent(in) :: desca(DLEN)
     real(dp), intent(inout) :: aa(desca(LLD), *)
@@ -89,12 +93,14 @@ interface
     real(dp), intent(inout) :: work(*)
     integer, intent(in) :: lwork
     integer, intent(inout) :: iwork(*)
+    integer, intent(in) :: liwork
     integer, intent(out) :: info
   end subroutine pdgetri
 
   subroutine pdgemm(transa, transb, mm, nn, kk, alpha, aa, ia, ja, desca, bb, ib, jb, descb, beta,&
       & cc, ic, jc, descc)
     import :: dp, DLEN, LLD
+    implicit none
     character, intent(in) :: transa, transb
     integer, intent(in) :: mm, nn, kk
     real(dp), intent(in) :: alpha
@@ -113,6 +119,7 @@ interface
   subroutine pzgemm(transa, transb, mm, nn, kk, alpha, aa, ia, ja, desca, bb, ib, jb, descb, beta,&
       & cc, ic, jc, descc)
     import :: dp, DLEN, LLD
+    implicit none
     character, intent(in) :: transa, transb
     integer, intent(in) :: mm, nn, kk
     complex(dp), intent(in) :: alpha
@@ -141,7 +148,7 @@ subroutine pinvh_real(A, blacs, exc, src)
     integer, allocatable :: i_pivot(:), iwork_arr(:)
     real(dp), allocatable :: work_arr(:)
     integer :: n, n_work_arr, error_flag, n_iwork_arr
-    integer :: n_iwork_arr_dummy(1)
+    integer :: n_iwork_arr_optim(1)
     real(dp) :: n_work_arr_optim(1)
 
     n = 3*blacs%n_atoms
@@ -159,9 +166,10 @@ subroutine pinvh_real(A, blacs, exc, src)
     endif
     call PDGETRI( &
         n, A, 1, 1, blacs%desc, i_pivot, &
-        n_work_arr_optim, -1, n_iwork_arr_dummy, -1, error_flag &
+        n_work_arr_optim, -1, n_iwork_arr_optim, -1, error_flag &
     )
     n_work_arr = nint(n_work_arr_optim(1))
+    n_iwork_arr = n_iwork_arr_optim(1)
     allocate (work_arr(n_work_arr), iwork_arr(n_iwork_arr))
     call PDGETRI( &
         n, A, 1, 1, blacs%desc, i_pivot, &


### PR DESCRIPTION
Fixes issues with NAG compilation

* Uses explicit interfaces for BLACS/ScaLAPACK calls and makes sure to pass arguments of proper rank.

* Add '-mismatch' option for the MPI-wrappers to enable for inconsistent argument rank/type usage.